### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/EXAMPLE.md
+++ b/EXAMPLE.md
@@ -1,6 +1,6 @@
 Examples
 =========
-#https://api.github.com
+# https://api.github.com
 
 	{
 		current_user_url: "https://api.github.com/user",

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ You can also print Java code
 jsonutil -j https://api.github.com/repos/bashtian/jsonutils
 ```
 
-###Example
-####JSON
+### Example
+#### JSON
 ```json
 {
     "firstName": "John",
@@ -66,7 +66,7 @@ jsonutil -j https://api.github.com/repos/bashtian/jsonutils
     "tags": ["music","video"]
 }
 ```
-####Go
+#### Go
 	
 	jsonutil -x -c=false -f Example.json
 	


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
